### PR TITLE
fix: Wrap whole $REPO_NAME parsing pattern between double quotes

### DIFF
--- a/wizard.sh
+++ b/wizard.sh
@@ -25,7 +25,7 @@ gum format -- "## Please input a name for the public repository on Github for yo
 echo
 REPO_NAME=$(gum input --placeholder "ie. my-ublue, org-name/silverblue-for-cats")
 gh repo create $REPO_NAME --source . --push --public
-if [ $REPO_NAME == *"/"* ]; then
+if [ $REPO_NAME == "*/*" ]; then
     REPO_FULL_NAME=$REPO_NAME
     gh repo set-default $REPO_FULL_NAME
 else


### PR DESCRIPTION
Hi :vulcan_salute:

When parsing the `$REPO_NAME` variable, the shell tries to run everything it finds in the execution directory and sub-directories because of the `*` asterisk:

```
...
To https://github.com/cig0/ublue-kinoite-nvidia-hci-cig0.git
 * [new branch]      HEAD -> main
branch 'main' set up to track 'origin/main'.
✓ Pushed commits to https://github.com/cig0/ublue-kinoite-nvidia-hci-cig0.git

sh: etc/profile.d: unknown operand

✓ Set cig0/ublue-kinoite-nvidia-hci-cig0 as the default repository for the current directory
Setting up git for changes...
Enabling container signing...
...
```

Wrapping the matching pattern between double quotes fixes this incorrect (and dangerous!) behavior.