### PR TITLE
Fix $REPO_NAME parsing by using a regexp

### DIFF
--- a/wizard.sh
+++ b/wizard.sh
@@ -25,7 +25,7 @@ gum format -- "## Please input a name for the public repository on Github for yo
 echo
 REPO_NAME=$(gum input --placeholder "ie. my-ublue, org-name/silverblue-for-cats")
 gh repo create $REPO_NAME --source . --push --public
-if [ $REPO_NAME == *"/"* ]; then
+if [ $REPO_NAME == "*/*" ]; then
     REPO_FULL_NAME=$REPO_NAME
     gh repo set-default $REPO_FULL_NAME
 else

--- a/wizard.sh
+++ b/wizard.sh
@@ -25,7 +25,7 @@ gum format -- "## Please input a name for the public repository on Github for yo
 echo
 REPO_NAME=$(gum input --placeholder "ie. my-ublue, org-name/silverblue-for-cats")
 gh repo create $REPO_NAME --source . --push --public
-if [ $REPO_NAME == "*/*" ]; then
+if [[ $REPO_NAME =~ ^[^/]+/[^/]+$ ]]; then
     REPO_FULL_NAME=$REPO_NAME
     gh repo set-default $REPO_FULL_NAME
 else


### PR DESCRIPTION
So, this PR properly fixes the issue described in https://github.com/EinoHR/create-ublue-image/pull/16

```
/host/my-ublue # REPO_NAME=cig0/my-ublue
/host/my-ublue # [[ $REPO_NAME =~ ^[^/]+/[^/]+$ ]] && echo True || echo False
True
/host/my-ublue # REPO_NAME=my-ublue
/host/my-ublue # [[ $REPO_NAME =~ ^[^/]+/[^/]+$ ]] && echo True || echo False
False
```