### PR TITLE
fix wizard script

### DIFF
--- a/wizard.sh
+++ b/wizard.sh
@@ -7,7 +7,7 @@ cd /host
 
 gum format -- "To get started, please log in to Github. This is used to set up the repository, **nothing will be deleted or modified, only added!** You can read the source code of this script in [the repo](https://github.com/EinoHR/create-ublue-image/)."
 echo
-gh auth login -p https -w
+gh auth login -p https -w -s workflow
 GIT_USER=$(gh api /user | jq '.login' -r)
 
 echo

--- a/wizard.sh
+++ b/wizard.sh
@@ -25,13 +25,16 @@ gum format -- "## Please input a name for the public repository on Github for yo
 echo
 REPO_NAME=$(gum input --placeholder "ie. my-ublue, org-name/silverblue-for-cats")
 gh repo create $REPO_NAME --source . --push --public
-if [ $REPO_NAME == *"/"* ]; then
-    REPO_FULL_NAME=$REPO_NAME
-    gh repo set-default $REPO_FULL_NAME
-else
-    REPO_FULL_NAME=$GIT_USER/$REPO_NAME
-    gh repo set-default $REPO_FULL_NAME
-fi
+case "$REPO_NAME" in
+  */*)
+    REPO_FULL_NAME="$REPO_NAME"
+    gh repo set-default "$REPO_FULL_NAME"
+    ;;
+  *)
+    REPO_FULL_NAME="$GIT_USER"/"$REPO_NAME"
+    gh repo set-default "$REPO_FULL_NAME"
+    ;;
+esac
 
 echo "Setting up git for changes..."
 git config user.name $GIT_USER


### PR DESCRIPTION
While executing `podman run -v "$(pwd)":/host:z -it ghcr.io/einohr/create-ublue-image`, I wasn't able to get the wizard script to complete for various reasons as indicated in each commit (insufficient permissions and a string parsing issue). The changes marked as "chore" aren't critical, but shouldn't hurt.